### PR TITLE
Added dbus-i2c package.

### DIFF
--- a/defaultPackageList
+++ b/defaultPackageList
@@ -18,3 +18,7 @@ RpiDisplaySetup     kwindrem    latest
 RpiGpioSetup        kwindrem    latest
 123SmartBMS-Venus	123electric	latest
 FroniusSmartmeter   SirUli      main
+dbus-i2c            pulquero    latest
+DCSystemAggregator  pulquero    latest
+gatt-exec-server    pulquero    latest
+BatteryProxy        pulquero    latest


### PR DESCRIPTION
DBus I2C functionality written in an extensible way (BME280 included, further devices are pluggable) and packaged up.