### PR TITLE
Increased version number fields

### DIFF
--- a/FileSets/MbDisplayPackageVersion.qml
+++ b/FileSets/MbDisplayPackageVersion.qml
@@ -133,7 +133,7 @@ MbItem {
 			{
 				id: gitHubVersion
 				item { bind: getServiceBind("GitHubVersion") }
-				height: 20; width: 80
+				height: 20; width: 90
 			}
 			Text // puts a bit of space below version boxes - only needed in one column
 			{
@@ -158,7 +158,7 @@ MbItem {
 			{
 				id: packageVersion
 				item { bind: getServiceBind("PackageVersion") }
-				height: 20; width: 80
+				height: 20; width: 90
 			}
 		}
 		Column
@@ -178,7 +178,7 @@ MbItem {
 			{
 				id: installedVersion
 				item { bind: getServiceBind("InstalledVersion") }
-				height: 20; width: 80
+				height: 20; width: 90
 			}
 		}
     }

--- a/FileSets/PageSettingsPackageEdit.qml
+++ b/FileSets/PageSettingsPackageEdit.qml
@@ -176,7 +176,7 @@ MbPage {
             {
                 id: gitHubVersion
                 item { bind: getServiceBind("GitHubVersion") }
-                height: 25; width: 80
+                height: 25; width: 90
             }
             Text
             {
@@ -188,7 +188,7 @@ MbPage {
             {
                 id: packageVersion
                 item { bind: getServiceBind("PackageVersion") }
-                height: 25; width: 80
+                height: 25; width: 90
             }
             Text
             {
@@ -230,7 +230,7 @@ MbPage {
                 id: installedVersion
                 item { bind: getServiceBind("InstalledVersion") }
                 height: 25
-                width: incompatible ? 0 : 80
+                width: incompatible ? 0 : 90
             }
         }
         MbEditBox


### PR DESCRIPTION
For one project I need more space for the version number (see https://github.com/henne49/dbus-opendtu/pull/122):

![sh-version-number](https://github.com/kwindrem/SetupHelper/assets/11308345/79ed3ed7-b5fe-4e0d-bc42-519eec11fe8c)

This PR increases the fields from 80 to 90 pixel:

![sh-pkg-edit](https://github.com/kwindrem/SetupHelper/assets/11308345/917b2746-6a35-474b-a003-1a3c3ca93661)
![sh-act-pkg](https://github.com/kwindrem/SetupHelper/assets/11308345/aa1988e0-92db-4184-83a3-1ea7ab85f982)

May be we need to adjust the labels (e.g. `installed:` -> `inst:`)?