### PR TITLE
Add victron-mpi5006-touch: QDtech MPI5001/MPI5006 touch fix for Cerbo GX

### DIFF
--- a/defaultPackageList
+++ b/defaultPackageList
@@ -25,3 +25,4 @@ gatt-exec-server      pulquero      latest
 dbus-pi               pulquero      latest
 FroniusSmartmeter     SirUli        main
 RemoteGPIO            Lucifer06     main
+victron-mpi5006-touch misko903      setuphelper


### PR DESCRIPTION
## Summary

Adds `victron-mpi5006-touch` to `defaultPackageList`.

**Package:** https://github.com/misko903/victron-mpi5006-touch (branch: `setuphelper`)

## What it does

Fixes broken touch input for the **QDtech MPI5001 / MPI5006** 5-inch HDMI touchscreen on a **Victron Cerbo GX** running Venus OS (venus-gui-v2).

**Root cause:** `hid-generic` maps `ABS_X`/`ABS_Y` from HID Finger 3 (always inactive, always reports max coords 800x480).

**Solution:** Python bridge reads raw HID reports, parses Finger 1 coords, forwards via uinput virtual touchscreen. Packaged as a runit service with auto-restart.

## Features
- Dynamic USB device discovery by VID:PID
- Auto-reconnect on USB disconnect
- Optional HDMI auto-blank after configurable timeout
- Survives Venus OS firmware updates via SetupHelper reinstall