### PR TITLE
Add inverter-control and dbus-mqtt-battery to default package list

### DIFF
--- a/defaultPackageList
+++ b/defaultPackageList
@@ -25,3 +25,6 @@ gatt-exec-server      pulquero      latest
 dbus-pi               pulquero      latest
 FroniusSmartmeter     SirUli        main
 RemoteGPIO            Lucifer06     main
+inverter-control      victron-venus latest
+dbus-mqtt-battery     victron-venus latest
+dbus-tasmota-pv       victron-venus latest


### PR DESCRIPTION
- inverter-control: Victron inverter controller with D-term, burst logic
- dbus-mqtt-battery: MQTT to D-Bus bridge for JBD BMS batteries

Both maintained under victron-venus GitHub org.